### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/YunFirstConfig/YunFirstConfig.ino
+++ b/examples/YunFirstConfig/YunFirstConfig.ino
@@ -301,7 +301,7 @@ void startSerialTerminal() {
   SERIAL_PORT_HARDWARE.begin(linuxBaud); // open serial connection to Linux
 }
 
-boolean commandMode = false;
+bool commandMode = false;
 void loopSerialTerminal() {
   // copy from USB-CDC to UART
   int c = SERIAL_PORT_USBVIRTUAL.read();    // read from USB-CDC

--- a/examples/YunSerialTerminal/YunSerialTerminal.ino
+++ b/examples/YunSerialTerminal/YunSerialTerminal.ino
@@ -38,7 +38,7 @@ void setup() {
   SERIAL_PORT_HARDWARE.begin(linuxBaud); // open serial connection to Linux
 }
 
-boolean commandMode = false;
+bool commandMode = false;
 
 void loop() {
   // copy from USB-CDC to UART


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633