### PR TITLE
Correct KEYWORD_TOKENTYPE of FileIO keyword

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,7 +7,7 @@
 #######################################
 
 Bridge	KEYWORD1	YunBridgeLibrary
-FileIO	KEYWORD4	YunFileIOConstructor
+FileIO	KEYWORD1	YunFileIOConstructor
 FileSystem	KEYWORD1	YunFileIOConstructor
 Console	KEYWORD1	YunConsoleConstructor
 Process	KEYWORD1	YunProcessConstructor


### PR DESCRIPTION
The use of the `KEYWORD4` KEYWORD_TOKENTYPE causes the keyword to be colored according to `editor.operator.style` in Arduino IDE 1.6.4 and older, which certainly doesn't make sense. It causes the keyword to default to the `editor.function.style` coloration on Arduino IDE 1.6.5 and newer.